### PR TITLE
Update Endpoint to handle automatically assigned ports

### DIFF
--- a/source/NetCoreServer/SslServer.cs
+++ b/source/NetCoreServer/SslServer.cs
@@ -145,6 +145,8 @@ namespace NetCoreServer
 
             // Bind the acceptor socket to the IP endpoint
             _acceptorSocket.Bind(Endpoint);
+            // Refresh the endpoint property based on the actual endpoint created
+            Endpoint = (IPEndPoint)_acceptorSocket.LocalEndPoint;
             // Start listen to the acceptor socket with the given accepting backlog size
             _acceptorSocket.Listen(_acceptorBacklog);
 

--- a/source/NetCoreServer/TcpServer.cs
+++ b/source/NetCoreServer/TcpServer.cs
@@ -136,6 +136,8 @@ namespace NetCoreServer
 
             // Bind the acceptor socket to the IP endpoint
             _acceptorSocket.Bind(Endpoint);
+            // Refresh the endpoint property based on the actual endpoint created
+            Endpoint = (IPEndPoint)_acceptorSocket.LocalEndPoint;
             // Start listen to the acceptor socket with the given accepting backlog size
             _acceptorSocket.Listen(_acceptorBacklog);
 

--- a/source/NetCoreServer/UdpServer.cs
+++ b/source/NetCoreServer/UdpServer.cs
@@ -150,6 +150,8 @@ namespace NetCoreServer
 
             // Bind the server socket to the IP endpoint
             Socket.Bind(Endpoint);
+            // Refresh the endpoint property based on the actual endpoint created
+            Endpoint = (IPEndPoint)Socket.LocalEndPoint;
 
             // Prepare receive endpoint
             _receiveEndpoint = new IPEndPoint((Endpoint.AddressFamily == AddressFamily.InterNetworkV6) ? IPAddress.IPv6Any : IPAddress.Any, 0);


### PR DESCRIPTION
When creating a server with port 0 (automatically assigned), there is no easy way to get the port on which the socket was actually created as the Endpoint property is not updated after binding.
This change fixes the problem.