### PR TITLE
Update ConnectedSessions to return a real value

### DIFF
--- a/source/NetCoreServer/SslServer.cs
+++ b/source/NetCoreServer/SslServer.cs
@@ -58,7 +58,7 @@ namespace NetCoreServer
         /// <summary>
         /// Number of sessions connected to the server
         /// </summary>
-        public long ConnectedSessions { get; internal set; }
+        public long ConnectedSessions { get { return _sessions.Count; } }
         /// <summary>
         /// Number of bytes pending sent by the server
         /// </summary>

--- a/source/NetCoreServer/TcpServer.cs
+++ b/source/NetCoreServer/TcpServer.cs
@@ -49,7 +49,7 @@ namespace NetCoreServer
         /// <summary>
         /// Number of sessions connected to the server
         /// </summary>
-        public long ConnectedSessions { get; internal set; }
+        public long ConnectedSessions { get { return _sessions.Count; } }
         /// <summary>
         /// Number of bytes pending sent by the server
         /// </summary>


### PR DESCRIPTION
ConnectedSessions always returns 0. This changes associates it with the Session collection.