### PR TITLE
Update SslSession.cs

### DIFF
--- a/source/NetCoreServer/SslSession.cs
+++ b/source/NetCoreServer/SslSession.cs
@@ -158,12 +158,17 @@ namespace NetCoreServer
 
             try
             {
+                try
+                {
                 // Shutdown the SSL stream
-                _sslStream.ShutdownAsync().Wait();
+                    _sslStream.ShutdownAsync().Wait();
 
-                // Dispose the SSL stream & buffer
-                _sslStream.Dispose();
-                _sslStreamId = null;
+                    // Dispose the SSL stream & buffer
+                    _sslStream.Dispose();
+                    _sslStreamId = null;
+                }
+                catch (System.IO.IOException) { }
+                catch (AggregateException) { }
 
                 try
                 {


### PR DESCRIPTION
Fix - server crashes after client disconnects immediately:
Exception triggered: "System.IO.IOException" in System.Private.CoreLib.dll
Exception triggered: "System.AggregateException" in System.Private.CoreLib.dll