### PR TITLE
Update SslClient.cs

### DIFF
--- a/source/NetCoreServer/SslClient.cs
+++ b/source/NetCoreServer/SslClient.cs
@@ -245,8 +245,13 @@ namespace NetCoreServer
 
             try
             {
-                // Shutdown the SSL stream
-                _sslStream.ShutdownAsync().Wait();
+                try
+                {
+                    // Shutdown the SSL stream
+                    _sslStream.ShutdownAsync().Wait();
+                }
+                catch (AggregateException) {}
+                catch (IOException) {}
 
                 // Dispose the SSL stream & buffer
                 _sslStream.Dispose();


### PR DESCRIPTION
Fix - client crashes after server disconnects immediately:
Exception triggered: "System.IO.IOException" in System.Private.CoreLib.dll
Exception triggered: "System.AggregateException" in System.Private.CoreLib.dll