### PR TITLE
Performance optimization: SendAsync: call TrySend within Task

### DIFF
--- a/source/NetCoreServer/SslClient.cs
+++ b/source/NetCoreServer/SslClient.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetCoreServer
 {
@@ -500,7 +501,7 @@ namespace NetCoreServer
             }
 
             // Try to send the main buffer
-            TrySend();
+            Task.Factory.StartNew(TrySend);
 
             return true;
         }

--- a/source/NetCoreServer/SslSession.cs
+++ b/source/NetCoreServer/SslSession.cs
@@ -4,6 +4,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetCoreServer
 {
@@ -347,7 +348,7 @@ namespace NetCoreServer
             }
 
             // Try to send the main buffer
-            TrySend();
+            Task.Factory.StartNew(TrySend);
 
             return true;
         }

--- a/source/NetCoreServer/TcpClient.cs
+++ b/source/NetCoreServer/TcpClient.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetCoreServer
 {
@@ -436,7 +437,7 @@ namespace NetCoreServer
             }
 
             // Try to send the main buffer
-            TrySend();
+            Task.Factory.StartNew(TrySend);
 
             return true;
         }

--- a/source/NetCoreServer/TcpSession.cs
+++ b/source/NetCoreServer/TcpSession.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetCoreServer
 {
@@ -318,7 +319,7 @@ namespace NetCoreServer
             }
 
             // Try to send the main buffer
-            TrySend();
+            Task.Factory.StartNew(TrySend);
 
             return true;
         }

--- a/source/NetCoreServer/UdpClient.cs
+++ b/source/NetCoreServer/UdpClient.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetCoreServer
 {
@@ -465,7 +466,7 @@ namespace NetCoreServer
             _sendEndpoint = endpoint;
 
             // Try to send the main buffer
-            TrySend();
+            Task.Factory.StartNew(TrySend);
 
             return true;
         }

--- a/source/NetCoreServer/UdpServer.cs
+++ b/source/NetCoreServer/UdpServer.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetCoreServer
 {
@@ -459,7 +460,7 @@ namespace NetCoreServer
             _sendEndpoint = endpoint;
 
             // Try to send the main buffer
-            TrySend();
+            Task.Factory.StartNew(TrySend);
 
             return true;
         }


### PR DESCRIPTION
Related issue #48 

Calling TrySend asynchronously (within new Task) to match the behavior of CppServer.

Benchmark results before:
```
TcpMulticastClient -c 100 -p 53698
Total time: 10.095 s
Total data: 27.1016 MiB
Total messages: 917256
Data throughput: 2.791 MiB/s
Message latency: 11.006 mcs
Message throughput: 90857 msg/s
```
Benchmark results after:
```
TcpMulticastClient -c 100 -p 53698
Total time: 10.202 s
Total data: 295.201 MiB
Total messages: 9673002
Data throughput: 28.954 MiB/s
Message latency: 1.054 mcs
Message throughput: 948056 msg/s
```

Before applying this fix, the _sendBufferFlush data size that was sent using SendAsync in the benchmark was constant size = 32 very low comparing to CppServer, where I had 6 digit sizes:
```c++
std::cout << "SEND SIZE: " << _send_buffer_flush.size() - _send_buffer_flush_offset << std::endl;
if (_strand_required)
    _socket.async_write_some(asio::buffer(_send_buffer_flush.data() + _send_buffer_flush_offset, _send_buffer_flush.size() - _send_buffer_flush_offset), bind_executor(_strand, async_write_handler));
else
    _socket.async_write_some(asio::buffer(_send_buffer_flush.data() + _send_buffer_flush_offset, _send_buffer_flush.size() - _send_buffer_flush_offset), async_write_handler);
```
```
SEND SIZE: 275232
SEND SIZE: 538112
SEND SIZE: 581248
SEND SIZE: 433248
SEND SIZE: 193696
SEND SIZE: 564864
SEND SIZE: 557216
SEND SIZE: 570080
SEND SIZE: 217312
SEND SIZE: 396128
SEND SIZE: 591968
```

That caused that the NetCoreServer sent single TCP packets with 32 bytes of data each, but the CppServer sent packets with much bigger sizes (max TCP packet sizes). It seems that without this fix, sending buffered data (multiple messages in `_sendBufferFlush`) was not properly working when calling SendAsync in a loop in single-thread