### PR TITLE
Add dual stack socket support

### DIFF
--- a/source/NetCoreServer/SslClient.cs
+++ b/source/NetCoreServer/SslClient.cs
@@ -103,6 +103,14 @@ namespace NetCoreServer
         /// Option: send buffer size
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
+        /// <summary>
+        /// Option: dual mode socket
+        /// </summary>
+        /// <remarks>
+        /// Specifies whether the Socket is a dual-mode socket used for both IPv4 and IPv6
+        /// Will work only if socket is bound on IPv6 address
+        /// </remarks>
+        public bool OptionDualMode { get; set; }
 
         #region Connect/Disconnect client
 
@@ -153,6 +161,10 @@ namespace NetCoreServer
 
             // Create a new client socket
             Socket = new Socket(Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            // Apply the option: dual mode; this option must be applied before connecting
+            if (Socket.AddressFamily == AddressFamily.InterNetworkV6)
+                Socket.DualMode = OptionDualMode;
 
             try
             {
@@ -340,6 +352,10 @@ namespace NetCoreServer
 
             // Create a new client socket
             Socket = new Socket(Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            // Apply the option: dual mode; this option must be applied before connecting
+            if (Socket.AddressFamily == AddressFamily.InterNetworkV6)
+                Socket.DualMode = OptionDualMode;
 
             // Async connect to the server
             IsConnecting = true;

--- a/source/NetCoreServer/SslServer.cs
+++ b/source/NetCoreServer/SslServer.cs
@@ -115,6 +115,14 @@ namespace NetCoreServer
         /// Option: send buffer size
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
+        /// <summary>
+        /// Option: dual mode socket
+        /// </summary>
+        /// <remarks>
+        /// Specifies whether the Socket is a dual-mode socket used for both IPv4 and IPv6
+        /// Will work only if socket is bound on IPv6 address
+        /// </remarks>
+        public bool OptionDualMode { get; set; }
 
         #region Start/Stop server
 
@@ -160,6 +168,9 @@ namespace NetCoreServer
             _acceptorSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, OptionReuseAddress);
             // Apply the option: exclusive address use
             _acceptorSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, OptionExclusiveAddressUse);
+            // Apply the option: dual mode; this option must be applied before listening
+            if (_acceptorSocket.AddressFamily == AddressFamily.InterNetworkV6)
+                _acceptorSocket.DualMode = OptionDualMode;
 
             // Bind the acceptor socket to the IP endpoint
             _acceptorSocket.Bind(Endpoint);

--- a/source/NetCoreServer/TcpClient.cs
+++ b/source/NetCoreServer/TcpClient.cs
@@ -88,6 +88,14 @@ namespace NetCoreServer
         /// Option: send buffer size
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
+        /// <summary>
+        /// Option: dual mode socket
+        /// </summary>
+        /// <remarks>
+        /// Specifies whether the Socket is a dual-mode socket used for both IPv4 and IPv6
+        /// Will work only if socket is bound on IPv6 address
+        /// </remarks>
+        public bool OptionDualMode { get; set; }
 
         #region Connect/Disconnect client
 
@@ -131,6 +139,10 @@ namespace NetCoreServer
 
             // Create a new client socket
             Socket = new Socket(Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            // Apply the option: dual mode; this option must be applied before connecting
+            if (Socket.AddressFamily == AddressFamily.InterNetworkV6)
+                Socket.DualMode = OptionDualMode;
 
             try
             {
@@ -275,6 +287,10 @@ namespace NetCoreServer
 
             // Create a new client socket
             Socket = new Socket(Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            // Apply the option: dual mode; this option must be applied before connecting
+            if (Socket.AddressFamily == AddressFamily.InterNetworkV6)
+                Socket.DualMode = OptionDualMode;
 
             // Async connect to the server
             IsConnecting = true;

--- a/source/NetCoreServer/TcpServer.cs
+++ b/source/NetCoreServer/TcpServer.cs
@@ -106,6 +106,14 @@ namespace NetCoreServer
         /// Option: send buffer size
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
+        /// <summary>
+        /// Option: dual mode socket
+        /// </summary>
+        /// <remarks>
+        /// Specifies whether the Socket is a dual-mode socket used for both IPv4 and IPv6
+        /// Will work only if socket is bound on IPv6 address
+        /// </remarks>
+        public bool OptionDualMode { get; set; }
 
         #region Start/Stop server
 
@@ -151,6 +159,9 @@ namespace NetCoreServer
             _acceptorSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, OptionReuseAddress);
             // Apply the option: exclusive address use
             _acceptorSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, OptionExclusiveAddressUse);
+            // Apply the option: dual mode; this option must be applied before listening
+            if (_acceptorSocket.AddressFamily == AddressFamily.InterNetworkV6)
+                _acceptorSocket.DualMode = OptionDualMode;
 
             // Bind the acceptor socket to the IP endpoint
             _acceptorSocket.Bind(Endpoint);

--- a/source/NetCoreServer/UdpClient.cs
+++ b/source/NetCoreServer/UdpClient.cs
@@ -99,6 +99,14 @@ namespace NetCoreServer
         /// Option: send buffer size
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
+        /// <summary>
+        /// Option: dual mode socket
+        /// </summary>
+        /// <remarks>
+        /// Specifies whether the Socket is a dual-mode socket used for both IPv4 and IPv6
+        /// Will work only if socket is bound on IPv6 address
+        /// </remarks>
+        public bool OptionDualMode { get; set; }
 
         #region Connect/Disconnect client
 
@@ -136,6 +144,9 @@ namespace NetCoreServer
             Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, OptionReuseAddress);
             // Apply the option: exclusive address use
             Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, OptionExclusiveAddressUse);
+            // Apply the option: dual mode; this option must be applied before recieving/sending
+            if (Socket.AddressFamily == AddressFamily.InterNetworkV6)
+                Socket.DualMode = OptionDualMode;
 
             // Bind the acceptor socket to the IP endpoint
             if (OptionMulticast)

--- a/source/NetCoreServer/UdpServer.cs
+++ b/source/NetCoreServer/UdpServer.cs
@@ -100,6 +100,14 @@ namespace NetCoreServer
         /// Option: send buffer size
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
+        /// <summary>
+        /// Option: dual mode socket
+        /// </summary>
+        /// <remarks>
+        /// Specifies whether the Socket is a dual-mode socket used for both IPv4 and IPv6
+        /// Will work only if socket is bound on IPv6 address
+        /// </remarks>
+        public bool OptionDualMode { get; set; }
 
         #region Connect/Disconnect client
 
@@ -138,6 +146,9 @@ namespace NetCoreServer
             Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, OptionReuseAddress);
             // Apply the option: exclusive address use
             Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, OptionExclusiveAddressUse);
+            // Apply the option: dual mode; this option must be applied before recieving
+            if (Socket.AddressFamily == AddressFamily.InterNetworkV6)
+                Socket.DualMode = OptionDualMode;
 
             // Bind the server socket to the IP endpoint
             Socket.Bind(Endpoint);


### PR DESCRIPTION
Add [Socket.DualMode](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.dualmode?view=netcore-3.1) support.
If socket is bound to IPv6 and this option is set to true, that allows socket to handle both ipv6 and mapped_to_ipv6 ipv4 addresses.