### PR TITLE
In some cases, the value of the header may be empty.

### DIFF
--- a/source/NetCoreServer/HttpResponse.cs
+++ b/source/NetCoreServer/HttpResponse.cs
@@ -836,7 +836,7 @@ namespace NetCoreServer
                             return false;
 
                         // Validate header name and value
-                        if ((headerNameSize == 0) || (headerValueSize == 0))
+                        if (headerNameSize == 0)
                             return false;
 
                         // Add a new header


### PR DESCRIPTION
case: https://www.taosj.com/restapi/taosj/plugin/item/info