### PR TITLE
.NET standard target

### DIFF
--- a/source/NetCoreServer/NetCoreServer.csproj
+++ b/source/NetCoreServer/NetCoreServer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <Version>5.0.5.0</Version>
+    <TargetFrameworks>net5.0; netstandard2.1</TargetFrameworks>
+    <Version>5.0.6.0</Version>
     <Authors>Ivan Shynkarenka</Authors>
     <Copyright>Copyright (c) 2019-2021 Ivan Shynkarenka</Copyright>
     <RepositoryUrl>https://github.com/chronoxor/NetCoreServer</RepositoryUrl>


### PR DESCRIPTION
I added netstandard2.1 target to allow the library to be used in Mono and Xamarin apps. 