### PR TITLE
fix HttpSession and HttpsSession loading file with query string from Cache

### DIFF
--- a/source/NetCoreServer/HttpSession.cs
+++ b/source/NetCoreServer/HttpSession.cs
@@ -178,7 +178,8 @@
             // Try to get the cached response
             if (request.Method == "GET")
             {
-                var response = Cache.Find(request.Url);
+                var index = request.Url.IndexOf("?");
+                var response = Cache.Find(index < 0 ? request.Url : request.Url.Substring(0, index));
                 if (response.Item1)
                 {
                     SendAsync(response.Item2);

--- a/source/NetCoreServer/HttpsSession.cs
+++ b/source/NetCoreServer/HttpsSession.cs
@@ -178,7 +178,8 @@
             // Try to get the cached response
             if (request.Method == "GET")
             {
-                var response = Cache.Find(request.Url);
+                var index = request.Url.IndexOf("?");
+                var response = Cache.Find(index < 0 ? request.Url : request.Url.Substring(0, index));
                 if (response.Item1)
                 {
                     SendAsync(response.Item2);


### PR DESCRIPTION
Statics url with query string are not loaded from Cache.

- http://static.localdomain.localhost/fonts/materialdesignicons-webfont.woff : loaded from cache
- http://static.localdomain.localhost/fonts/materialdesignicons-webfont.woff?v=5.4.99 : not loaded

This patch fix the URL parameter in Cache.Find()

Thanks.