### PR TITLE
Add option to TCP client/session to send remaining bytes when disconnecting

### DIFF
--- a/source/NetCoreServer/TcpSession.cs
+++ b/source/NetCoreServer/TcpSession.cs
@@ -71,6 +71,14 @@ namespace NetCoreServer
         /// </summary>
         public int OptionSendBufferSize { get; set; } = 8192;
 
+        /// <summary>
+        /// Option: whether to send all remaining bytes when disconnecting
+        /// </summary>
+        /// <remarks>
+        /// This only affects bytes end via SendAsync(...)
+        /// </remarks>
+        public bool OptionSendRemainingBytesOnDisconnect { get; set; } = false;
+
         #region Connect/Disconnect session
 
         /// <summary>
@@ -154,6 +162,12 @@ namespace NetCoreServer
             if (!IsConnected)
                 return false;
 
+            // Wait for pending asynchronous send operations if desired
+            if (OptionSendRemainingBytesOnDisconnect)
+            {
+                _sendBuffersEmpty.WaitOne();
+            }
+
             // Reset event args
             _receiveEventArg.Completed -= OnAsyncCompleted;
             _sendEventArg.Completed -= OnAsyncCompleted;
@@ -225,6 +239,7 @@ namespace NetCoreServer
         private Buffer _sendBufferFlush;
         private SocketAsyncEventArgs _sendEventArg;
         private long _sendBufferFlushOffset;
+        private readonly ManualResetEvent _sendBuffersEmpty = new ManualResetEvent(true);
 
         /// <summary>
         /// Send data to the client (synchronous)
@@ -309,6 +324,7 @@ namespace NetCoreServer
                 }
 
                 // Fill the main send buffer
+                _sendBuffersEmpty.Reset();
                 _sendBufferMain.Append(buffer, offset, size);
 
                 // Update statistic
@@ -473,6 +489,8 @@ namespace NetCoreServer
                 // Call the empty send buffer handler
                 if (empty)
                 {
+                    _sendBuffersEmpty.Set();
+
                     OnEmpty();
                     return;
                 }
@@ -628,6 +646,8 @@ namespace NetCoreServer
                 return true;
             else
             {
+                _sendBuffersEmpty.Set();
+
                 SendError(e.SocketError);
                 Disconnect();
                 return false;
@@ -753,6 +773,7 @@ namespace NetCoreServer
                 {
                     // Dispose managed resources here...
                     Disconnect();
+                    _sendBuffersEmpty.Dispose();
                 }
 
                 // Dispose unmanaged resources here...


### PR DESCRIPTION
Adds an option for the TcpSession/TcpClient to delay a disconnect until all queued asynchronous send operations are completed.

The option is called `OptionSendRemainingBytesOnDisconnect`. The thread causing the disconnect is blocked until all remaining bytes have been sent. This option can be used to avoid calling the blocking `Send(...)` functions while still ensuring that all data is send.