### PR TITLE
Added GenerateDocumentationFile option for project

### DIFF
--- a/source/NetCoreServer/NetCoreServer.csproj
+++ b/source/NetCoreServer/NetCoreServer.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>	
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>	
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>	
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Intellisense documentation is not available for consumers using the nuget package, added the flag to generate the documentation file to fix this.