### PR TITLE
Close status updates

### DIFF
--- a/examples/HttpClient/HttpClient.csproj
+++ b/examples/HttpClient/HttpClient.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/HttpServer/HttpServer.csproj
+++ b/examples/HttpServer/HttpServer.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/HttpsClient/HttpsClient.csproj
+++ b/examples/HttpsClient/HttpsClient.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/examples/HttpsServer/HttpsServer.csproj
+++ b/examples/HttpsServer/HttpsServer.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/examples/ProtoClient/ProtoClient.csproj
+++ b/examples/ProtoClient/ProtoClient.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\proto\proto.csproj" />
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/ProtoServer/ProtoServer.csproj
+++ b/examples/ProtoServer/ProtoServer.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\proto\proto.csproj" />
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/SslChatClient/SslChatClient.csproj
+++ b/examples/SslChatClient/SslChatClient.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/examples/SslChatServer/SslChatServer.csproj
+++ b/examples/SslChatServer/SslChatServer.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/examples/TcpChatClient/TcpChatClient.csproj
+++ b/examples/TcpChatClient/TcpChatClient.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/TcpChatServer/TcpChatServer.csproj
+++ b/examples/TcpChatServer/TcpChatServer.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/UdpEchoClient/UdpEchoClient.csproj
+++ b/examples/UdpEchoClient/UdpEchoClient.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/UdpEchoServer/UdpEchoServer.csproj
+++ b/examples/UdpEchoServer/UdpEchoServer.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/UdpMulticastClient/UdpMulticastClient.csproj
+++ b/examples/UdpMulticastClient/UdpMulticastClient.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/UdpMulticastServer/UdpMulticastServer.csproj
+++ b/examples/UdpMulticastServer/UdpMulticastServer.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/UdsChatClient/UdsChatClient.csproj
+++ b/examples/UdsChatClient/UdsChatClient.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/UdsChatServer/UdsChatServer.csproj
+++ b/examples/UdsChatServer/UdsChatServer.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/WsChatClient/WsChatClient.csproj
+++ b/examples/WsChatClient/WsChatClient.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/WsChatServer/WsChatServer.csproj
+++ b/examples/WsChatServer/WsChatServer.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/examples/WssChatClient/WssChatClient.csproj
+++ b/examples/WssChatClient/WssChatClient.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/examples/WssChatServer/WssChatServer.csproj
+++ b/examples/WssChatServer/WssChatServer.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/HttpTraceClient/HttpTraceClient.csproj
+++ b/performance/HttpTraceClient/HttpTraceClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/HttpTraceServer/HttpTraceServer.csproj
+++ b/performance/HttpTraceServer/HttpTraceServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/HttpsTraceClient/HttpsTraceClient.csproj
+++ b/performance/HttpsTraceClient/HttpsTraceClient.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/HttpsTraceServer/HttpsTraceServer.csproj
+++ b/performance/HttpsTraceServer/HttpsTraceServer.csproj
@@ -1,22 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/ProtoClient/ProtoClient.csproj
+++ b/performance/ProtoClient/ProtoClient.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\proto\proto.csproj" />
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/ProtoServer/ProtoServer.csproj
+++ b/performance/ProtoServer/ProtoServer.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\proto\proto.csproj" />
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/SslEchoClient/SslEchoClient.csproj
+++ b/performance/SslEchoClient/SslEchoClient.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/SslEchoServer/SslEchoServer.csproj
+++ b/performance/SslEchoServer/SslEchoServer.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/SslMulticastClient/SslMulticastClient.csproj
+++ b/performance/SslMulticastClient/SslMulticastClient.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/SslMulticastServer/SslMulticastServer.csproj
+++ b/performance/SslMulticastServer/SslMulticastServer.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/TcpEchoClient/TcpEchoClient.csproj
+++ b/performance/TcpEchoClient/TcpEchoClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/TcpEchoServer/TcpEchoServer.csproj
+++ b/performance/TcpEchoServer/TcpEchoServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/TcpMulticastClient/TcpMulticastClient.csproj
+++ b/performance/TcpMulticastClient/TcpMulticastClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/TcpMulticastServer/TcpMulticastServer.csproj
+++ b/performance/TcpMulticastServer/TcpMulticastServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdpEchoClient/UdpEchoClient.csproj
+++ b/performance/UdpEchoClient/UdpEchoClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdpEchoServer/UdpEchoServer.csproj
+++ b/performance/UdpEchoServer/UdpEchoServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdpMulticastClient/UdpMulticastClient.csproj
+++ b/performance/UdpMulticastClient/UdpMulticastClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdpMulticastServer/UdpMulticastServer.csproj
+++ b/performance/UdpMulticastServer/UdpMulticastServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdsEchoClient/UdsEchoClient.csproj
+++ b/performance/UdsEchoClient/UdsEchoClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdsEchoServer/UdsEchoServer.csproj
+++ b/performance/UdsEchoServer/UdsEchoServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdsMulticastClient/UdsMulticastClient.csproj
+++ b/performance/UdsMulticastClient/UdsMulticastClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/UdsMulticastServer/UdsMulticastServer.csproj
+++ b/performance/UdsMulticastServer/UdsMulticastServer.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/WsEchoClient/WsEchoClient.csproj
+++ b/performance/WsEchoClient/WsEchoClient.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/WsEchoServer/WsEchoServer.csproj
+++ b/performance/WsEchoServer/WsEchoServer.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/WsMulticastClient/WsMulticastClient.csproj
+++ b/performance/WsMulticastClient/WsMulticastClient.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/WsMulticastServer/WsMulticastServer.csproj
+++ b/performance/WsMulticastServer/WsMulticastServer.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/performance/WssEchoClient/WssEchoClient.csproj
+++ b/performance/WssEchoClient/WssEchoClient.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/WssEchoServer/WssEchoServer.csproj
+++ b/performance/WssEchoServer/WssEchoServer.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/WssMulticastClient/WssMulticastClient.csproj
+++ b/performance/WssMulticastClient/WssMulticastClient.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/performance/WssMulticastServer/WssMulticastServer.csproj
+++ b/performance/WssMulticastServer/WssMulticastServer.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\tools\certificates\server.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/proto/proto.csproj
+++ b/proto/proto.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/source/NetCoreServer/NetCoreServer.csproj
+++ b/source/NetCoreServer/NetCoreServer.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>7.0.0.0</Version>
     <Authors>Ivan Shynkarenka</Authors>
     <Copyright>Copyright (c) 2019-2022 Ivan Shynkarenka</Copyright>
@@ -11,10 +10,8 @@
     <PackageProjectUrl>https://github.com/chronoxor/NetCoreServer</PackageProjectUrl>
     <PackageTags>async;client;server;tcp;udp;ssl;tls;http;https;websocket;low latency;performance</PackageTags>
   </PropertyGroup>
-
   <PropertyGroup>
-    <IncludeSymbols>true</IncludeSymbols>	
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>	
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
 </Project>

--- a/source/NetCoreServer/WebSocket.cs
+++ b/source/NetCoreServer/WebSocket.cs
@@ -470,7 +470,7 @@ namespace NetCoreServer
                                     int status = 1000;
 
                                     // Read WebSocket close status
-                                    if (WsReceiveFinalBuffer.Size > 2)
+                                    if (WsReceiveFinalBuffer.Size >= 2)
                                     {
                                         sindex += 2;
                                         status = ((WsReceiveFinalBuffer[0] << 8) | (WsReceiveFinalBuffer[1] << 0));

--- a/source/NetCoreServer/WsSession.cs
+++ b/source/NetCoreServer/WsSession.cs
@@ -15,7 +15,12 @@ namespace NetCoreServer
         public WsSession(WsServer server) : base(server) { WebSocket = new WebSocket(this); }
 
         // WebSocket connection methods
-        public virtual bool Close(int status) { SendCloseAsync(status, Span<byte>.Empty); base.Disconnect(); return true; }
+        public virtual bool Close(int status) => Close(status, Span<byte>.Empty);
+        public virtual bool Close(int status, string text) => Close(status, Encoding.UTF8.GetBytes(text));
+        public virtual bool Close(int status, ReadOnlySpan<char> text) => Close(status, Encoding.UTF8.GetBytes(text.ToArray()));
+        public virtual bool Close(int status, byte[] buffer) => Close(status, buffer.AsSpan());
+        public virtual bool Close(int status, byte[] buffer, long offset, long size) => Close(status, buffer.AsSpan((int)offset, (int)size));
+        public virtual bool Close(int status, ReadOnlySpan<byte> buffer) { SendCloseAsync(status, buffer); base.Disconnect(); return true; }
 
         #region WebSocket send text methods
 

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -13,12 +11,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\proto\proto.csproj" />
     <ProjectReference Include="..\source\NetCoreServer\NetCoreServer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\tools\certificates\client.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -27,5 +23,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
In our testing, the status code was not being sent with no message, as the close(status) method suggested it would. When we tested with the SendCloseAsync methods and included a message, the status was not being set properly, and there was an "index out of bounds" error that caused the connection to not close. These fixes address the problems, and additionally, more close methods have been added so that the message can be more easily included on closures.

Note: we could have put the mask frame content loop outside of the if statement and shared it for both cases by using buffer[i - index] instead, but figured that this way would be slightly faster without the extra operation for regular (non-close) message frames.