### PR TITLE
fix(UdpServer): Avoid debug assertion if disposing not started server

### DIFF
--- a/source/NetCoreServer/UdpServer.cs
+++ b/source/NetCoreServer/UdpServer.cs
@@ -934,7 +934,10 @@ namespace NetCoreServer
                 if (disposingManagedResources)
                 {
                     // Dispose managed resources here...
-                    Stop();
+                    if (IsStarted)
+                    {
+                        Stop();
+                    }
                 }
 
                 // Dispose unmanaged resources here...


### PR DESCRIPTION
There is currently the following assertion in `Stop()`: `Debug.Assert(IsStarted, "UDP server is not started!");`, however it should be valid to dispose the object without the server being started.